### PR TITLE
Allow using env creds

### DIFF
--- a/cuckoo/machinery/aws.py
+++ b/cuckoo/machinery/aws.py
@@ -43,9 +43,13 @@ class AWS(Machinery):
         self.dynamic_machines_sequence = 0
         self.dynamic_machines_count = 0
         log.info("connecting to AWS:{}".format(self.options.aws.region_name))
-        self.ec2_resource = boto3.resource(
-            "ec2", region_name=self.options.aws.region_name, aws_access_key_id=self.options.aws.aws_access_key_id,
-            aws_secret_access_key=self.options.aws.aws_secret_access_key)
+
+        if not self.options.aws.aws_access_key_id or not self.options.aws.aws_secret_access_key:
+            self.ec2_resource = boto3.resource("ec2", region_name=self.options.aws.region_name)
+        else:
+            self.ec2_resource = boto3.resource(
+                "ec2", region_name=self.options.aws.region_name, aws_access_key_id=self.options.aws.aws_access_key_id,
+                aws_secret_access_key=self.options.aws.aws_secret_access_key)
 
         # Iterate over all instances with tag that has a key of AUTOSCALE_CUCKOO
         for instance in self.ec2_resource.instances.filter(Filters=[{"Name": "instance-state-name",

--- a/cuckoo/private/cwd/conf/aws.conf
+++ b/cuckoo/private/cwd/conf/aws.conf
@@ -8,6 +8,7 @@ availability_zone = {{ aws.aws.availability_zone }}
 # Access keys consist of two parts: an access key ID (for example, AKIAIOSFODNN7EXAMPLE)
 # and a secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY).
 # To create access keys for your AWS account root user, you must use the AWS Management Console.
+# Leaving these empty will default to picking up credential information from environment or EC2 metadata
 aws_access_key_id = {{ aws.aws.aws_access_key_id }}
 aws_secret_access_key = {{ aws.aws.aws_secret_access_key }}
 


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
I added the ability for the agent to pick up cred from the env. Rather than forcing users to use IAM user, this allows users to user to use IAM roles. When running on the agent on AWS ideally you won't use IAM user because within AWS you have access to IAM roles. IAM roles tend to have session time out where IAM users do not. 

##### The goal of my change is:
Allow a safer way to run the agent on AWS by allowing user to use IAM role rather than IAM user. 

##### What I have tested about my change is:
Need to work on this. I haven't tested yet
